### PR TITLE
Update language around Certificate Transparency

### DIFF
--- a/CPS.md
+++ b/CPS.md
@@ -46,8 +46,7 @@ The following revisions have been made:
 | November 14, 2018 | Remove user notice text from end-entity certificate profile in Section 7.1. | 2.5 |
 | July 3, 2019 | Minor grammatical and capitalization changes. | 2.6 |
 | January 21, 2020 | Make structure more exactly match RFC 3647 recommendation. Audit use of phrase No Stipulation and eliminate blank sections. Remove restriction on issuance for IP addresses in Section 7.1.5. Update lists of appropriate and prohibited certificate uses in Sections 1.4.1 and 1.4.2. Clarify annual vulnerability assessment requirements in Section 5.4.8. | 2.7 |
-| X Y, Z | Specify in Section 4.9.3 that revocations for key compromise will result in blocking of the public key for future issuance and revocation of other outstanding certificates with the key. | 2.8 |
-| X Y, Z | Update description of Certificate Transparency submissions. | 2.8 |
+| X Y, Z | Specify in Section 4.9.3 that revocations for key compromise will result in blocking of the public key for future issuance and revocation of other outstanding certificates with the key. Update description of Certificate Transparency submissions. | 2.8 |
 
 ## 1.3 PKI participants
 

--- a/CPS.md
+++ b/CPS.md
@@ -358,8 +358,6 @@ The source of a certificate request is confirmed before issuance. CA processes a
 
 End-entity certificates are made available to Subscribers via the ACME protocol as soon after issuance as reasonably possible. Typically this happens within a few seconds.
 
-All end-entity certificates are logged to Certificate Transparency servers as soon as reasonably possible. Typically this happens within a few seconds.
-
 ## 4.4 Certificate acceptance
 
 ### 4.4.1 Conduct constituting certificate acceptance
@@ -372,7 +370,7 @@ All root and intermediate certificates are made available publicly via the Certi
 
 All end-entity certificates are made available to Subscribers via the ACME protocol.
 
-All end-entity certificates are logged to Certificate Transparency servers.
+End-entity certificates received by Subscribers are also logged to Certificate Transparency servers in precertificate form. The final (non-precertificate) form of those certificates is logged to Certificate Transparency servers on a best-effort basis.
 
 ### 4.4.3 Notification of certificate issuance by the CA to other entities
 

--- a/CPS.md
+++ b/CPS.md
@@ -47,6 +47,7 @@ The following revisions have been made:
 | July 3, 2019 | Minor grammatical and capitalization changes. | 2.6 |
 | January 21, 2020 | Make structure more exactly match RFC 3647 recommendation. Audit use of phrase No Stipulation and eliminate blank sections. Remove restriction on issuance for IP addresses in Section 7.1.5. Update lists of appropriate and prohibited certificate uses in Sections 1.4.1 and 1.4.2. Clarify annual vulnerability assessment requirements in Section 5.4.8. | 2.7 |
 | X Y, Z | Specify in Section 4.9.3 that revocations for key compromise will result in blocking of the public key for future issuance and revocation of other outstanding certificates with the key. | 2.8 |
+| X Y, Z | Update description of Certificate Transparency submissions. | 2.8 |
 
 ## 1.3 PKI participants
 
@@ -388,7 +389,12 @@ All root and intermediate certificates are made available publicly via the Certi
 
 All end-entity certificates are made available to Subscribers via the ACME protocol.
 
-End-entity certificates received by Subscribers are also logged to Certificate Transparency servers in precertificate form. The final (non-precertificate) form of those certificates is logged to Certificate Transparency servers on a best-effort basis.
+For each end-entity certificate issuance, ISRG signs a Precertificate and
+submits it to a selection of Certificate Transparency logs. Upon successful
+submission, ISRG issues a certificate that matches the Precertificate
+(per RFC 6962 Section 3.1) and embeds at least two of the resulting Signed
+Certificate Timestamps (SCTs). ISRG submits the resulting certificate to a
+selection of Certificate Transparency logs on a best-effort basis.
 
 ### 4.4.3 Notification of certificate issuance by the CA to other entities
 


### PR DESCRIPTION
This clarifies the precertificate-based issuance flow.