### PR TITLE
no-stipulations: Adding first version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+.vscode
+*.pyc
+.DS_Store

--- a/tools/no-stipulations/no_stipulation.py
+++ b/tools/no-stipulations/no_stipulation.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import argparse
+
+
+def make_no_stipulations(old_content: list) -> str:
+    new_content = []
+    for i in range(len(old_content)):
+        curr_line = old_content[i]
+        # Unconditionally append the first line to avoid index wrap-around.
+        if i == 0:
+            new_content.append(curr_line)
+            continue
+        prev_line = old_content[i - 1]
+        if curr_line == "\n":
+            if prev_line[0] == "#":
+                if i < len(old_content) - 1:
+                    next_line = old_content[i + 1]
+                    if next_line[0] == "#" and len(prev_line.split("#")) >= len(next_line.split("#")):
+                        new_content.append(curr_line + "No stipulation.\n\n")
+                    else:
+                        new_content.append(curr_line)
+                else:
+                    new_content.append(curr_line + "No stipulation.\n\n")
+            else:
+                new_content.append(curr_line)
+        else:
+            new_content.append(curr_line)
+
+    return "".join(new_content)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Replaces empty policy sections with 'No stipulation.'"
+    )
+    parser.add_argument(
+        "-d",
+        "--document",
+        metavar="PATH",
+        type=argparse.FileType("r"),
+        required=True,
+        help="path to the policy document to edit you wish to edit",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        metavar="PATH",
+        type=argparse.FileType("w"),
+        required=True,
+        help="path to output the edited policy document",
+    )
+
+    args = parser.parse_args()
+    contents = args.document.readlines()
+    args.document.close()
+
+    new_content = make_no_stipulations(contents)
+    args.output.write(new_content)
+    args.output.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/no-stipulations/no_stipulation_test.py
+++ b/tools/no-stipulations/no_stipulation_test.py
@@ -1,0 +1,143 @@
+import io
+import unittest
+
+from no_stipulation import make_no_stipulations
+
+document_input = io.StringIO(
+"""---
+title: Testament of Tester Testington
+subtitle: Version 1.0
+author:
+  - Tester Testington
+date: 3 June, 2021  
+copyright: |
+  Copyright 2021 Tester Testington of Test Town
+
+  This work is licensed under the Conspicuous Attribution 4.0 NT for Workgroups Testing license.
+---
+
+# 1. LOREM
+
+## 1.1 Ipsum
+
+### 1.1.1 Dolor
+
+### 1.1.2 Sit
+
+### 1.1.3 Amet
+
+Some content.
+
+### 1.1.4 Consectetur
+
+### 1.1.5 Adipiscing
+
+### 1.1.6 Elit
+
+## 1.2 Sed
+
+### 1.2.1 Do
+
+Some multi-line
+Content just to be
+Safe
+
+### 1.2.2 Eiusmod
+
+Some more content, finally!
+
+# 2. Tempor
+
+## 2.1 Incididunt
+
+### 2.1.1 Ut
+
+Some multi-paragraph
+
+Content just to be
+
+Safe
+
+## 2.2 Labore
+
+Something else.
+
+""").readlines()
+
+document_output = """---
+title: Testament of Tester Testington
+subtitle: Version 1.0
+author:
+  - Tester Testington
+date: 3 June, 2021  
+copyright: |
+  Copyright 2021 Tester Testington of Test Town
+
+  This work is licensed under the Conspicuous Attribution 4.0 NT for Workgroups Testing license.
+---
+
+# 1. LOREM
+
+## 1.1 Ipsum
+
+### 1.1.1 Dolor
+
+No stipulation.
+
+### 1.1.2 Sit
+
+No stipulation.
+
+### 1.1.3 Amet
+
+Some content.
+
+### 1.1.4 Consectetur
+
+No stipulation.
+
+### 1.1.5 Adipiscing
+
+No stipulation.
+
+### 1.1.6 Elit
+
+No stipulation.
+
+## 1.2 Sed
+
+### 1.2.1 Do
+
+Some multi-line
+Content just to be
+Safe
+
+### 1.2.2 Eiusmod
+
+Some more content, finally!
+
+# 2. Tempor
+
+## 2.1 Incididunt
+
+### 2.1.1 Ut
+
+Some multi-paragraph
+
+Content just to be
+
+Safe
+
+## 2.2 Labore
+
+Something else.
+
+"""
+
+class TestMakeNoStipulations(unittest.TestCase):
+    def test_make_no_stipulations_empty(self):
+        self.assertEqual(make_no_stipulations(""), "")
+
+    def test_make_no_stipulations_happy_path(self):
+        self.maxDiff = None
+        self.assertEqual(make_no_stipulations(document_input), document_output)

--- a/workflows/pr_tools.yml
+++ b/workflows/pr_tools.yml
@@ -1,0 +1,38 @@
+name: Test Tools
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test no-stipulations
+        working-directory: ./tools/no-stipulations/
+        run: |
+          python3 -m unittest *_test.py


### PR DESCRIPTION
Operates on [this]( https://github.com/cabforum/servercert/blob/main/docs/BR.md) document. Inserts "No stipulation." into any section that is blank and has no subsections.

- Add `tools/no_stipulations/no_stipulation.py` with unit tests
- Add github actions to `flake8` and `unittest`