### PR TITLE
Update CP for BRs v1.7.8

### DIFF
--- a/CP.md
+++ b/CP.md
@@ -3,7 +3,7 @@ title: Internet Security Research Group (ISRG) Certificate Policy
 subtitle: Version 2.8
 author:
   - Internet Security Research Group
-date: X Y, Z
+date: DD Month, YYYY
 copyright:
   Copyright 2021 CA/Browser Forum
   Copyright 2021 Internet Security Research Group
@@ -60,7 +60,7 @@ This is the ISRG Certificate Policy. This document was approved for publication 
 | October 27, 2020 | List ISRG Root X2 in section 1.1. Update sections 3.2.2.4, 3.2.2.5, 3.2.2.6, 3.2.2.8, 4.2.1, 4.9.10, 7.1.2, and 7.1.3 regarding validation methods, OCSP, certificate profiles, and cryptographic algorithms, to match Baseline Requirements. | 2.5 |
 | April 2, 2021 | Update ISRG physical address. | 2.6 |
 | June 8, 2021 | Update Sections 4.2.1, 4.2.2, 4.9.1.1, 6.3.2, and 7.1.4.2.1 to match BRs v1.7.6. Define Internal Name in Section 1.6.1. | 2.7 |
-| X Y, Z | Sync against Baseline Requirements v1.7.6. | 2.8 |
+| DD Month, YYYY | Sync against Baseline Requirements v1.7.8. | 2.8 |
 
 ### 1.2.2 Relevant Dates
 
@@ -100,7 +100,9 @@ This is the ISRG Certificate Policy. This document was approved for publication 
 | 2020-09-30 | 7.1.4.1 | Subject and Issuer Names for all possible certification paths MUST be byte-for-byte identical. |
 | 2020-09-30 | 7.1.6.4 | Subscriber Certificates MUST include a CA/Browser Form Reserved Policy Identifier in the Certificate Policies extension. |
 | 2020-09-30 | 7.2 and 7.3 | All OCSP and CRL responses for Subordinate CA Certificates MUST include a meaningful reason code. |
+| 2021-07-01 | 3.2.2.8 | CAA checking is no longer optional if the CA is the DNS Operator or an Affiliate. |
 | 2021-07-01 | 3.2.2.4.18 and 3.2.2.4.19 | Redirects MUST be the result of one of the HTTP status code responses defined.  |
+| 2021-12-01 | 3.2.2.4 | CAs MUST NOT use methods 3.2.2.4.6, 3.2.2.4.18, or 3.2.2.4.19 to issue wildcard certificates or with Authorization Domain Names other than the FQDN. |
 
 ## 1.3 PKI Participants
 
@@ -419,7 +421,7 @@ The script outputs:
 | DBA | Doing Business As |
 | DNS | Domain Name System |
 | FIPS | (US Government) Federal Information Processing Standard |
-| FQDN | Fully Qualified Domain Name |
+| FQDN | Fully-Qualified Domain Name |
 | IM | Instant Messaging |
 | IANA | Internet Assigned Numbers Authority |
 | ICANN | Internet Corporation for Assigned Names and Numbers |
@@ -694,7 +696,7 @@ If a Random Value is used, the CA SHALL provide a Random Value unique to the Cer
 
 Confirming the Applicant's control over the FQDN by confirming that the Applicant controls an IP address returned from a DNS lookup for A or AAAA records for the FQDN in accordance with [Section 3.2.2.5](#3225-authentication-for-an-ip-address).
 
-**Note**: Once the FQDN has been validated using this method, the CA MAY NOT also issue Certificates for other FQDNs that end with all the labels of the validated FQDN unless the CA performs a separate validation for that FQDN using an authorized method. This method is NOT suitable for validating Wildcard Domain Names.
+**Note**: Once the FQDN has been validated using this method, the CA MUST NOT issue Certificates for other FQDNs that end with all the labels of the validated FQDN unless the CA performs a separate validation for that FQDN using an authorized method. This method is NOT suitable for validating Wildcard Domain Names.
 
 ##### 3.2.2.4.9 Test Certificate
 
@@ -797,7 +799,9 @@ If a Random Value is used, then:
 1. The CA MUST provide a Random Value unique to the certificate request.
 2. The Random Value MUST remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values, in which case the CA MUST follow its CPS.
 
-**Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
+**Note**:
+  * For Certificates issued prior to 2021-12-01, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
+  * For Certificates issued on or after 2021-12-01, the CA MUST NOT issue Certificates for other FQDNs that end with all the labels of the validated FQDN unless the CA performs a separate validation for that FQDN using an authorized method. This method is NOT suitable for validating Wildcard Domain Names.
 
 ##### 3.2.2.4.19 Agreed-Upon Change to Website - ACME
 
@@ -815,7 +819,9 @@ If the CA follows redirects, the following apply:
 2. Redirects MUST be to resource URLs with either the "http" or "https" scheme.
 3. Redirects MUST be to resource URLs accessed via Authorized Ports.
 
-**Note**: Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
+**Note**:
+  * For Certificates issued prior to 2021-12-01, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
+  * For Certificates issued on or after 2021-12-01, the CA MUST NOT issue Certificates for other FQDNs that end with all the labels of the validated FQDN unless the CA performs a separate validation for that FQDN using an authorized method. This method is NOT suitable for validating Wildcard Domain Names.
 
 ##### 3.2.2.4.20 TLS Using ALPN
 
@@ -823,7 +829,7 @@ Confirming the Applicant's control over a FQDN by validating domain control of t
 
 The token (as defined in RFC 8737, Section 3) MUST NOT be used for more than 30 days from its creation. The CPS MAY specify a shorter validity period for the token, in which case the CA MUST follow its CPS.
 
-**Note**: Once the FQDN has been validated using this method, the CA MAY NOT also issue Certificates for other FQDNs that end with all the labels of the validated FQDN unless the CA performs a separate validation for that FQDN using an authorized method. This method is NOT suitable for validating Wildcard Domain Names.
+**Note**: Once the FQDN has been validated using this method, the CA MUST NOT issue Certificates for other FQDNs that end with all the labels of the validated FQDN unless the CA performs a separate validation for that FQDN using an authorized method. This method is NOT suitable for validating Wildcard Domain Names.
 
 #### 3.2.2.5 Authentication for an IP Address
 
@@ -922,7 +928,7 @@ RFC 8659 requires that CAs "MUST NOT issue a certificate unless the CA determine
 
 * CAA checking is optional for certificates for which a Certificate Transparency pre-certificate was created and logged in at least two public logs, and for which CAA was checked.
 * CAA checking is optional for certificates issued by a Technically Constrained Subordinate CA Certificate as set out in [Section 7.1.5](#715-name-constraints), where the lack of CAA checking is an explicit contractual provision in the contract with the Applicant.
-* CAA checking is optional if the CA or an Affiliate of the CA is the DNS Operator (as defined in RFC 7719) of the domain's DNS.
+* For certificates issued prior to July 1, 2021, CAA checking is optional if the CA or an Affiliate of the CA is the DNS Operator (as defined in RFC 7719) of the domain's DNS.
 
 CAs are permitted to treat a record lookup failure as permission to issue if:
 
@@ -2733,7 +2739,15 @@ This appendix defines permissible verification procedures for including one or m
 
 2. The CA MUST verify the Applicant’s control over the .onion Domain Name using at least one of the methods listed below:
 
-   a. The CA MAY verify the Applicant’s control over the .onion service by using method in [Section 3.2.2.4.6 - Agreed‐Upon Change to Website](#32246-agreed-upon-change-to-website). If this method is replaced by a newer version(s) of Agreed-Upon Change to Website, the timelines for use of new and existing version of this method that are defined in [Section 3.2.2.4](#3224-validation-of-domain-authorization-or-control) SHALL apply.
+   a. The CA MAY verify the Applicant's control over the .onion service by using one of the following methods from [Section 3.2.2.4](#3224-validation-of-domain-authorization-or-control):
+
+      i. [Section 3.2.2.4.6 - Agreed-Upon Change to Website](#32246-agreed-upon-change-to-website)
+      ii. [Section 3.2.2.4.18 - Agreed-Upon Change to Website v2](#322418-agreed-upon-change-to-website-v2)
+      iii. [Section 3.2.2.4.19 - Agreed-Upon Change to Website - ACME](#322419-agreed-upon-change-to-website-acme)
+
+      When these methods are used to verify the Applicant's control over the .onion service, the CA MUST use Tor protocol to establish a connection to the .onion hidden service. The CA MUST NOT delegate or rely on a third-party to establish the connection, such as by using Tor2Web.
+
+      **Note**: This section does not override or supersede any provisions specified within the respective methods. The CA MUST only use a method if it is still permitted within that section and MUST NOT issue Wildcard Certificates or use it as an Authorization Domain Name, except as specified by that method.
 
    b. The CA MAY verify the Applicant's control over the .onion service by having the Applicant provide a Certificate Request signed using the .onion public key if the Attributes section of the certificationRequestInfo contains:
 
@@ -2764,6 +2778,6 @@ This appendix defines permissible verification procedures for including one or m
 
       The Random Value SHALL remain valid for use in a confirming response for no more than 30 days from its creation. The CPS MAY specify a shorter validity period for Random Values.
 
-      The CA MAY include a wildcard character in the Subject Alternative Name Extension and Subject Common Name Field as the left-most character in the .onion Domain Name provided inclusion of the wildcard character complies with [Section 3.2.2.6](#3226-wildcard-domain-validation) of these Requirements.
+      Once the FQDN has been validated using this method, the CA MAY also issue Certificates for other FQDNs that end with all the labels of the validated FQDN. This method is suitable for validating Wildcard Domain Names.
 
 3. When a Certificate includes an FQDN where "onion" is in the right-most label of the Domain Name, the Domain Name shall not be considered an Internal Name provided that the Certificate was issued in compliance with this [Appendix B](#appendix-b--issuance-of-certificates-for-onion-domain-names).

--- a/patches/isrg-cp-from-brs.patch
+++ b/patches/isrg-cp-from-brs.patch
@@ -13,22 +13,22 @@ https://github.com/letsencrypt/cp-cps/blob/master/tools/no-stipulations/no_stipu
 @@ -1,11 +1,12 @@
  ---
 -title: Baseline Requirements for the Issuance and Management of Publicly-Trusted Certificates
--subtitle: Version 1.7.6
+-subtitle: Version 1.7.8
 +title: Internet Security Research Group (ISRG) Certificate Policy
 +subtitle: Version 2.8
  author:
 -  - CA/Browser Forum
--date: 3 June, 2021  
+-date: 13 July, 2021  
 -copyright: |
 +  - Internet Security Research Group
-+date: 6 July, 2021
++date: DD Month, YYYY
 +copyright:
    Copyright 2021 CA/Browser Forum
 +  Copyright 2021 Internet Security Research Group
  
    This work is licensed under the Creative Commons Attribution 4.0 International license.
  ---
-@@ -14,113 +15,52 @@ copyright: |
+@@ -14,115 +15,52 @@ copyright: |
  
  ## 1.1 Overview
  
@@ -154,6 +154,8 @@ https://github.com/letsencrypt/cp-cps/blob/master/tools/no-stipulations/no_stipu
 -| 1.7.4 | SC41 | Reformat the BRs, EVGs, and NCSSRs | 24-Feb-2021 | 5-Apr-2021 |
 -| 1.7.5 | SC42 | 398-day Re-use Period | 22-Apr-2021 | 2-Jun-2021 |
 -| 1.7.6 | SC44 | Clarify Acceptable Status Codes | 30-Apr-2021 | 3-Jun-2021 |
+-| 1.7.7 | SC46 | Sunset the CAA Exception for DNS Operator | 2-Jun-2021 | 12-Jul-2021 |
+-| 1.7.8 | SC45 | Wildcard Domain Validation | 2-Jun-2021 | 13-Jul-2021 |
 -
 -\* Effective Date and Additionally Relevant Compliance Date(s)
 +| Date              | Changes                                            | Version |
@@ -170,11 +172,11 @@ https://github.com/letsencrypt/cp-cps/blob/master/tools/no-stipulations/no_stipu
 +| October 27, 2020 | List ISRG Root X2 in section 1.1. Update sections 3.2.2.4, 3.2.2.5, 3.2.2.6, 3.2.2.8, 4.2.1, 4.9.10, 7.1.2, and 7.1.3 regarding validation methods, OCSP, certificate profiles, and cryptographic algorithms, to match Baseline Requirements. | 2.5 |
 +| April 2, 2021 | Update ISRG physical address. | 2.6 |
 +| June 8, 2021 | Update Sections 4.2.1, 4.2.2, 4.9.1.1, 6.3.2, and 7.1.4.2.1 to match BRs v1.7.6. Define Internal Name in Section 1.6.1. | 2.7 |
-+| July 6, 2021 | Sync against Baseline Requirements v1.7.6. | 2.8 |
++| DD Month, YYYY | Sync against Baseline Requirements v1.7.8. | 2.8 |
  
  ### 1.2.2 Relevant Dates
  
-@@ -168,7 +108,7 @@ The CA/Browser Forum is a voluntary organization of Certification Authorities an
+@@ -172,7 +110,7 @@ The CA/Browser Forum is a voluntary organization of Certification Authorities an
  
  ### 1.3.1 Certification Authorities
  
@@ -183,7 +185,7 @@ https://github.com/letsencrypt/cp-cps/blob/master/tools/no-stipulations/no_stipu
  
  ### 1.3.2 Registration Authorities
  
-@@ -198,13 +138,10 @@ As defined in [Section 1.6.1](#161-definitions).
+@@ -202,13 +140,10 @@ As defined in [Section 1.6.1](#161-definitions).
  
  ### 1.3.4 Relying Parties
  
@@ -198,7 +200,7 @@ https://github.com/letsencrypt/cp-cps/blob/master/tools/no-stipulations/no_stipu
  ## 1.4 Certificate Usage
  
  ### 1.4.1 Appropriate Certificate Uses
-@@ -217,23 +154,31 @@ No stipulation.
+@@ -221,23 +156,31 @@ No stipulation.
  
  ## 1.5 Policy administration
  
@@ -236,7 +238,7 @@ https://github.com/letsencrypt/cp-cps/blob/master/tools/no-stipulations/no_stipu
  
  ## 1.6 Definitions and Acronyms
  
-@@ -410,7 +355,7 @@ The script outputs:
+@@ -414,7 +357,7 @@ The script outputs:
  
  **Required Website Content**: Either a Random Value or a Request Token, together with additional information that uniquely identifies the Subscriber, as specified by the CA.
  
@@ -245,7 +247,7 @@ https://github.com/letsencrypt/cp-cps/blob/master/tools/no-stipulations/no_stipu
  
  **Reserved IP Address**: An IPv4 or IPv6 address that the IANA has marked as reserved:
  
-@@ -440,8 +385,6 @@ The script outputs:
+@@ -444,8 +387,6 @@ The script outputs:
  
  **Terms of Use**: Provisions regarding the safekeeping and acceptable uses of a Certificate issued in accordance with these Requirements when the Applicant/Subscriber is an Affiliate of the CA or is the CA.
  
@@ -254,7 +256,7 @@ https://github.com/letsencrypt/cp-cps/blob/master/tools/no-stipulations/no_stipu
  **Trustworthy System**: Computer hardware, software, and procedures that are: reasonably secure from intrusion and misuse; provide a reasonable level of availability, reliability, and correct operation; are reasonably suited to performing their intended functions; and enforce the applicable security policy.
  
  **Unregistered Domain Name**: A Domain Name that is not a Registered Domain Name.
-@@ -959,7 +902,7 @@ This stipulation does not prevent the CA from checking CAA records at any other
+@@ -967,7 +908,7 @@ This stipulation does not prevent the CA from checking CAA records at any other
  
  When processing CAA records, CAs MUST process the issue, issuewild, and iodef property tags as specified in RFC 8659, although they are not required to act on the contents of the iodef property tag. Additional property tags MAY be supported, but MUST NOT conflict with or supersede the mandatory property tags set out in this document. CAs MUST respect the critical flag and not issue a certificate if they encounter an unrecognized property tag with this flag set.
  
@@ -263,7 +265,7 @@ https://github.com/letsencrypt/cp-cps/blob/master/tools/no-stipulations/no_stipu
  
  * CAA checking is optional for certificates for which a Certificate Transparency pre-certificate was created and logged in at least two public logs, and for which CAA was checked.
  * CAA checking is optional for certificates issued by a Technically Constrained Subordinate CA Certificate as set out in [Section 7.1.5](#715-name-constraints), where the lack of CAA checking is an explicit contractual provision in the contract with the Applicant.
-@@ -1894,7 +1837,7 @@ b. semantics that, if included, will mislead a Relying Party about the certifica
+@@ -1902,7 +1843,7 @@ b. semantics that, if included, will mislead a Relying Party about the certifica
  
  #### 7.1.2.5 Application of RFC 5280
  
@@ -272,7 +274,7 @@ https://github.com/letsencrypt/cp-cps/blob/master/tools/no-stipulations/no_stipu
  
  ### 7.1.3 Algorithm object identifiers
  
-@@ -2266,7 +2209,7 @@ The CA SHALL at all times:
+@@ -2274,7 +2215,7 @@ The CA SHALL at all times:
  3. Comply with the audit requirements set forth in this section; and
  4. Be licensed as a CA in each jurisdiction where it operates, if licensing is required by the law of such jurisdiction for the issuance of Certificates.
  
@@ -281,7 +283,7 @@ https://github.com/letsencrypt/cp-cps/blob/master/tools/no-stipulations/no_stipu
  
  ## 8.1 Frequency or circumstances of assessment
  
-@@ -2460,7 +2403,7 @@ The Subscriber Agreement or Terms of Use MUST contain provisions imposing on the
+@@ -2468,7 +2409,7 @@ The Subscriber Agreement or Terms of Use MUST contain provisions imposing on the
  
  6. **Termination of Use of Certificate**: An obligation and warranty to promptly cease all use of the Private Key corresponding to the Public Key included in the Certificate upon revocation of that Certificate for reasons of Key Compromise.
  7. **Responsiveness**: An obligation to respond to the CA's instructions concerning Key Compromise or Certificate misuse within a specified time period.


### PR DESCRIPTION
Update the patch file to have the new BRs version, date, list of
changes, and diff chunk offsets. (Also rename the patch file to be
version-agnostic, as these updates will be necessary every time until we
have a better system.)

Use the updated patch file and the new v1.7.8 of the BRs to produce a
new CP, incorporating the diffs from Ballots SC46 ("Sunset the CAA
Exception for DNS Operators") and SC45 ("Wildcard Domain Validation").

Fixes #51
Fixes #113