### PR TITLE
Update CP to match BRs v1.8.3

### DIFF
--- a/CP.md
+++ b/CP.md
@@ -48,6 +48,7 @@ This is the ISRG Certificate Policy. This document was approved for publication 
 | July 19, 2021 | Sync against Baseline Requirements v1.7.8. | 3.0 |
 | August 20, 2021 | Update mailing address. Minor formatting changes. | 3.1 |
 | December 22, 2021 | Sync against Baseline Requirements v1.8.0. Minor updates. | 3.2 |
+| ??? ??, 2021 | Sync against Baseline Requirements v1.8.3. | 3.3 |
 
 ### 1.2.2 Relevant Dates
 
@@ -91,6 +92,7 @@ This is the ISRG Certificate Policy. This document was approved for publication 
 | 2021-07-01 | 3.2.2.4.18 and 3.2.2.4.19 | Redirects MUST be the result of one of the HTTP status code responses defined.  |
 | 2021-10-01 | 7.1.4.2.1 | Fully-Qualified Domain Names MUST consist solely of P-Labels and Non-Reserved LDH Labels. |
 | 2021-12-01 | 3.2.2.4 | CAs MUST NOT use methods 3.2.2.4.6, 3.2.2.4.18, or 3.2.2.4.19 to issue wildcard certificates or with Authorization Domain Names other than the FQDN. |
+| 2022-06-01 | 7.1.3.2.1 | CAs MUST NOT sign OCSP responses using the SHA-1 hash algorithm. |
 | 2022-09-01 | 7.1.4.2.2 | CAs MUST NOT include the organizationalUnitName field in the Subject |
 
 ## 1.3 PKI Participants
@@ -174,6 +176,8 @@ The ISRG Policy Management Authority is responsible for determining the suitabil
 The ISRG Policy Management Authority approves any revisions to the ISRG CPS after formal review.
 
 ## 1.6 Definitions and Acronyms
+
+The Definitions found in the CA/Browser Forum's Network and Certificate System Security Requirements are incorporated by reference as if fully set forth herein.
 
 ### 1.6.1 Definitions
 
@@ -994,7 +998,7 @@ No stipulation.
 
 ### 4.1.1 Who can submit a certificate application
 
-In accordance with [Section 5.5.2](#552-retention-period-for-archive), the CA SHALL maintain an internal database of all previously revoked Certificates and previously rejected certificate requests due to suspected phishing or other fraudulent usage or concerns. The CA SHALL use this information to identify subsequent suspicious certificate requests.
+No stipulation.
 
 ### 4.1.2 Enrollment process and responsibilities
 
@@ -1481,7 +1485,7 @@ No stipulation.
 
 ### 5.4.1 Types of events recorded
 
-The CA and each Delegated Third Party SHALL record details of the actions taken to process a certificate request and to issue a Certificate, including all information generated and documentation received in connection with the certificate request; the time and date; and the personnel involved. The CA SHALL make these records available to its Qualified Auditor as proof of the CA’s compliance with these Requirements.
+The CA and each Delegated Third Party SHALL record events related to the security of their Certificate Systems, Certificate Management Systems, Root CA Systems, and Delegated Third Party Systems. The CA and each Delegated Third Party SHALL record events related to their actions taken to process a certificate request and to issue a Certificate, including all information generated and documentation received in connection with the certificate request; the time and date; and the personnel involved. The CA SHALL make these records available to its Qualified Auditor as proof of the CA’s compliance with these Requirements.
 
 The CA SHALL record at least the following events:
 
@@ -1490,15 +1494,17 @@ The CA SHALL record at least the following events:
    2. Certificate requests, renewal, and re-key requests, and revocation;
    3. Approval and rejection of certificate requests;
    4. Cryptographic device lifecycle management events;
-   5. Generation of Certificate Revocation Lists and OCSP entries;
-   6. Introduction of new Certificate Profiles and retirement of existing Certificate Profiles.
+   5. Generation of Certificate Revocation Lists;
+   6. Signing of OCSP Responses (as described in [Section 4.9](#49-certificate-revocation-and-suspension) and [Section 4.10](#410-certificate-status-services)); and
+   7. Introduction of new Certificate Profiles and retirement of existing Certificate Profiles.
 
 2. Subscriber Certificate lifecycle management events, including:
    1. Certificate requests, renewal, and re-key requests, and revocation;
    2. All verification activities stipulated in these Requirements and the CA's Certification Practice Statement;
    3. Approval and rejection of certificate requests;
-   4. Issuance of Certificates; and
-   5. Generation of Certificate Revocation Lists and OCSP entries.
+   4. Issuance of Certificates; 
+   5. Generation of Certificate Revocation Lists; and 
+   6. Signing of OCSP Responses (as described in [Section 4.9](#49-certificate-revocation-and-suspension) and [Section 4.10](#410-certificate-status-services)).
 
 3. Security events, including:
    1. Successful and unsuccessful PKI system access attempts;
@@ -1511,33 +1517,35 @@ The CA SHALL record at least the following events:
 
 Log records MUST include the following elements:
 
-1. Date and time of record;
+1. Date and time of event;
 2. Identity of the person making the journal record; and
-3. Description of the record.
+3. Description of the event.
 
-### 5.4.2 Frequency for Processing and Archiving Audit Logs
+### 5.4.2 Frequency of processing audit log
 
 No stipulation.
 
-### 5.4.3 Retention Period for Audit Logs
+### 5.4.3 Retention period for audit log
 
-The CA SHALL retain, for at least two years:
+The CA and each Delegated Third Party SHALL retain, for at least two (2) years:
 
   1. CA certificate and key lifecycle management event records (as set forth in [Section 5.4.1](#541-types-of-events-recorded) (1)) after the later occurrence of:
      1. the destruction of the CA Private Key; or
      2. the revocation or expiration of the final CA Certificate in that set of Certificates that have an X.509v3 `basicConstraints` extension with the `cA` field set to true and which share a common Public Key corresponding to the CA Private Key;
-  2. Subscriber Certificate lifecycle management event records (as set forth in [Section 5.4.1](#541-types-of-events-recorded) (2)) after the revocation or expiration of the Subscriber Certificate;
+  2. Subscriber Certificate lifecycle management event records (as set forth in [Section 5.4.1](#541-types-of-events-recorded) (2)) after the expiration of the Subscriber Certificate;
   3. Any security event records (as set forth in [Section 5.4.1](#541-types-of-events-recorded) (3)) after the event occurred.
 
-### 5.4.4 Protection of Audit Log
+Note: While these Requirements set the minimum retention period, the CA MAY choose a greater value as more appropriate in order to be able to investigate possible security or other types of incidents that will require retrospection and examination of past audit log events.
+
+### 5.4.4 Protection of audit log
 
 No stipulation.
 
-### 5.4.5 Audit Log Backup Procedures
+### 5.4.5 Audit log backup procedures
 
 No stipulation.
 
-### 5.4.6 Audit Log Accumulation System (internal vs. external)
+### 5.4.6 Audit collection System (internal vs. external)
 
 No stipulation.
 
@@ -1557,11 +1565,23 @@ Additionally, the CA's security program MUST include an annual Risk Assessment t
 
 ### 5.5.1 Types of records archived
 
-No stipulation.
+The CA and each Delegated Party SHALL archive all audit logs (as set forth in [Section 5.4.1](#541-types-of-events-recorded)).
+
+Additionally, the CA and each Delegated Party SHALL archive:
+1. Documentation related to the security of their Certificate Systems, Certificate Management Systems, Root CA Systems, and Delegated Third Party Systems; and
+2. Documentation related to their verification, issuance, and revocation of certificate requests and Certificates.
 
 ### 5.5.2 Retention period for archive
 
-The CA SHALL retain all documentation relating to certificate requests and the verification thereof, and all Certificates and revocation thereof, for at least seven years after any Certificate based on that documentation ceases to be valid.
+Archived audit logs (as set forth in [Section 5.5.1](#551-types-of-records-archived) SHALL be retained for a period of at least two (2) years from their record creation timestamp, or as long as they are required to be retained per [Section 5.4.3](#543-retention-period-for-audit-log), whichever is longer.
+
+Additionally, the CA and each delegated party SHALL retain, for at least two (2) years:
+1. All archived documentation related to the security of Certificate Systems, Certificate Management Systems, Root CA Systems and Delegated Third Party Systems (as set forth in [Section 5.5.1](#551-types-of-records-archived)); and
+2. All archived documentation relating to the verification, issuance, and revocation of certificate requests and Certificates (as set forth in [Section 5.5.1](#551-types-of-records-archived)) after the later occurrence of:
+   1. such records and documentation were last relied upon in the verification, issuance, or revocation of certificate requests and Certificates; or
+   2. the expiration of the Subscriber Certificates relying upon such records and documentation.
+
+Note: While these Requirements set the minimum retention period, the CA MAY choose a greater value as more appropriate in order to be able to investigate possible security or other types of incidents that will require retrospection and examination of past records archived.
 
 ### 5.5.3 Protection of archive
 
@@ -2083,6 +2103,7 @@ In addition, the CA MAY use the following signature algorithm and encoding if al
     * The new Certificate's `extKeyUsage` extension is present, has at least one key purpose specified, and none of the key purposes specified are the id-kp-serverAuth (OID: 1.3.6.1.5.5.7.3.1) or the anyExtendedKeyUsage (OID: 2.5.2937.0) key purposes; and/or
     * The new Certificate's `basicConstraints` extension has a pathLenConstraint that is zero.
 * If used within an OCSP response, such as the `signatureAlgorithm` of a BasicOCSPResponse:
+  * The `producedAt` field value of the ResponseData MUST be earlier than 2022-06-01 00:00:00 UTC; and,
   * All unexpired, un-revoked Certificates that contain the Public Key of the CA Key Pair and that have the same Subject Name MUST also contain an `extKeyUsage` extension with the only key usage present being the id-kp-ocspSigning (OID: 1.3.6.1.5.5.7.3.9) key usage.
 * If used within a CRL, such as the `signatureAlgorithm` field of a CertificateList or the `signature` field of a TBSCertList:
   * The CRL is referenced by one or more Root CA or Subordinate CA Certificates; and,

--- a/patches/isrg-cp-from-brs.patch
+++ b/patches/isrg-cp-from-brs.patch
@@ -1,16 +1,16 @@
 diff --git a/servercert/docs/BR.md b/cp-cps/CP.md
-index 740ba53..a0c67c3 100644
+index e8ca9d1..ecadaf0 100644
 --- a/servercert/docs/BR.md
 +++ b/cp-cps/CP.md
-@@ -1,130 +1,53 @@
+@@ -1,133 +1,54 @@
 ----
 -title: Baseline Requirements for the Issuance and Management of Publicly-Trusted Certificates
--subtitle: Version 1.8.0
+-subtitle: Version 1.8.3
 -author:
 -  - CA/Browser Forum
--date: 25 August, 2021  
+-date: 15 April, 2022  
 -copyright: |
--  Copyright 2021 CA/Browser Forum
+-  Copyright 2022 CA/Browser Forum
 -
 -  This work is licensed under the Creative Commons Attribution 4.0 International license.
 ----
@@ -143,6 +143,9 @@ index 740ba53..a0c67c3 100644
 -| 1.7.8 | SC45 | Wildcard Domain Validation | 2-Jun-2021 | 13-Jul-2021 |
 -| 1.7.9 | SC47 | Sunset subject:organizationalUnitName | 30-Jun-2021 | 16-Aug-2021 |
 -| 1.8.0 | SC48 | Domain Name and IP Address Encoding | 22-Jul-2021 | 25-Aug-2021 |
+-| 1.8.1 | SC50 | Remove the requirements of 4.1.1 | 22-Nov-2021 | 23-Dec-2021 |
+-| 1.8.2 | SC53 | Sunset for SHA-1 OCSP Signing | 26-Jan-2022 | 4-Mar-2022 |
+-| 1.8.3 | SC51 | Reduce and Clarify Log and Records Archival Retention Requirements | 01-Mar-2021 | 15-Apr-2022 |
 -
 -\* Effective Date and Additionally Relevant Compliance Date(s)
 +| Date              | Changes                                            | Version |
@@ -161,11 +164,12 @@ index 740ba53..a0c67c3 100644
 +| June 8, 2021 | Update Sections 4.2.1, 4.2.2, 4.9.1.1, 6.3.2, and 7.1.4.2.1 to match BRs v1.7.6. Define Internal Name in Section 1.6.1. | 2.7 |
 +| July 19, 2021 | Sync against Baseline Requirements v1.7.8. | 3.0 |
 +| August 20, 2021 | Update mailing address. Minor formatting changes. | 3.1 |
-+| ??? ??, 2021 | Sync against Baseline Requirements v1.8.0. Minor updates. | 3.2 |
++| December 22, 2021 | Sync against Baseline Requirements v1.8.0. Minor updates. | 3.2 |
++| ??? ??, 2021 | Sync against Baseline Requirements v1.8.3. | 3.3 |
  
  ### 1.2.2 Relevant Dates
  
-@@ -176,7 +97,7 @@ The CA/Browser Forum is a voluntary organization of Certification Authorities an
+@@ -180,7 +101,7 @@ The CA/Browser Forum is a voluntary organization of Certification Authorities an
  
  ### 1.3.1 Certification Authorities
  
@@ -174,7 +178,7 @@ index 740ba53..a0c67c3 100644
  
  ### 1.3.2 Registration Authorities
  
-@@ -206,13 +127,10 @@ As defined in [Section 1.6.1](#161-definitions).
+@@ -210,13 +131,10 @@ As defined in [Section 1.6.1](#161-definitions).
  
  ### 1.3.4 Relying Parties
  
@@ -189,7 +193,7 @@ index 740ba53..a0c67c3 100644
  ## 1.4 Certificate Usage
  
  ### 1.4.1 Appropriate Certificate Uses
-@@ -225,23 +143,31 @@ No stipulation.
+@@ -229,23 +147,31 @@ No stipulation.
  
  ## 1.5 Policy administration
  
@@ -227,7 +231,7 @@ index 740ba53..a0c67c3 100644
  
  ## 1.6 Definitions and Acronyms
  
-@@ -426,7 +352,7 @@ The script outputs:
+@@ -432,7 +358,7 @@ The script outputs:
  
  **Required Website Content**: Either a Random Value or a Request Token, together with additional information that uniquely identifies the Subscriber, as specified by the CA.
  
@@ -236,7 +240,7 @@ index 740ba53..a0c67c3 100644
  
  **Reserved IP Address**: An IPv4 or IPv6 address that is contained in the address block of any entry in either of the following IANA registries:
  
-@@ -456,8 +382,6 @@ The script outputs:
+@@ -462,8 +388,6 @@ The script outputs:
  
  **Terms of Use**: Provisions regarding the safekeeping and acceptable uses of a Certificate issued in accordance with these Requirements when the Applicant/Subscriber is an Affiliate of the CA or is the CA.
  
@@ -245,7 +249,7 @@ index 740ba53..a0c67c3 100644
  **Trustworthy System**: Computer hardware, software, and procedures that are: reasonably secure from intrusion and misuse; provide a reasonable level of availability, reliability, and correct operation; are reasonably suited to performing their intended functions; and enforce the applicable security policy.
  
  **Unregistered Domain Name**: A Domain Name that is not a Registered Domain Name.
-@@ -992,7 +916,7 @@ This stipulation does not prevent the CA from checking CAA records at any other
+@@ -998,7 +922,7 @@ This stipulation does not prevent the CA from checking CAA records at any other
  
  When processing CAA records, CAs MUST process the issue, issuewild, and iodef property tags as specified in RFC 8659, although they are not required to act on the contents of the iodef property tag. Additional property tags MAY be supported, but MUST NOT conflict with or supersede the mandatory property tags set out in this document. CAs MUST respect the critical flag and not issue a certificate if they encounter an unrecognized property tag with this flag set.
  
@@ -254,7 +258,7 @@ index 740ba53..a0c67c3 100644
  
  * CAA checking is optional for certificates for which a Certificate Transparency pre-certificate was created and logged in at least two public logs, and for which CAA was checked.
  * CAA checking is optional for certificates issued by a Technically Constrained Subordinate CA Certificate as set out in [Section 7.1.5](#715-name-constraints), where the lack of CAA checking is an explicit contractual provision in the contract with the Applicant.
-@@ -1927,7 +1851,7 @@ b. semantics that, if included, will mislead a Relying Party about the certifica
+@@ -1951,7 +1875,7 @@ b. semantics that, if included, will mislead a Relying Party about the certifica
  
  #### 7.1.2.5 Application of RFC 5280
  
@@ -263,7 +267,7 @@ index 740ba53..a0c67c3 100644
  
  ### 7.1.3 Algorithm object identifiers
  
-@@ -2306,7 +2230,7 @@ The CA SHALL at all times:
+@@ -2331,7 +2255,7 @@ The CA SHALL at all times:
  3. Comply with the audit requirements set forth in this section; and
  4. Be licensed as a CA in each jurisdiction where it operates, if licensing is required by the law of such jurisdiction for the issuance of Certificates.
  
@@ -272,7 +276,7 @@ index 740ba53..a0c67c3 100644
  
  ## 8.1 Frequency or circumstances of assessment
  
-@@ -2500,7 +2424,7 @@ The Subscriber Agreement or Terms of Use MUST contain provisions imposing on the
+@@ -2525,7 +2449,7 @@ The Subscriber Agreement or Terms of Use MUST contain provisions imposing on the
  
  6. **Termination of Use of Certificate**: An obligation and warranty to promptly cease all use of the Private Key corresponding to the Public Key included in the Certificate upon revocation of that Certificate for reasons of Key Compromise.
  7. **Responsiveness**: An obligation to respond to the CA's instructions concerning Key Compromise or Certificate misuse within a specified time period.


### PR DESCRIPTION
This updates our CP to match BRs v1.8.3, which pulls in ballots:
- SC50: Remove the requirements of 4.1.1
- SC53: Sunset for SHA-1 OCSP Signing
- SC51: Reduce and Clarify Log and Records Archival Retention Requirements

Fixes #166
Fixes #167