### PR TITLE
Add IssuingDistributionPoint to Subordinate CA CRL Profile

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -1125,7 +1125,7 @@ For the status of Subordinate CA Certificates:
 | NextUpdate                | Up to ThisUpdate + 1 year                                                      |
 | RevokedCertificates       | Contains: userCertificate, revocationDate, reasonCode                          |
 | CRLnumber                 | The serial number of this CRL in an incrementally increasing sequence of CRLs  |
-| IssuingDistributionPoint  | Contains a distributionPoint pointing to the CRL's unique URL                  |
+| IssuingDistributionPoint  | Optional: may assert onlyContainsCACerts                                       |
 
 For the status of Subscriber Certificates:
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -1125,6 +1125,7 @@ For the status of Subordinate CA Certificates:
 | NextUpdate                | Up to ThisUpdate + 1 year                                                      |
 | RevokedCertificates       | Contains: userCertificate, revocationDate, reasonCode                          |
 | CRLnumber                 | The serial number of this CRL in an incrementally increasing sequence of CRLs  |
+| IssuingDistributionPoint  | Contains a distributionPoint pointing to the CRL's unique URL                  |
 
 For the status of Subscriber Certificates:
 


### PR DESCRIPTION
To date we have never revoked an intermediate and thus never updated an intermediate CRL, but we should be prepared to create for such an event.

Related to https://github.com/letsencrypt/boulder/issues/7047.