### PR TITLE
Replace prohibited certificate usage with reference to Subscriber Agreement

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -72,7 +72,7 @@ No stipulation.
 
 ### 1.4.2 Prohibited certificate uses
 
-Prohibited certificate usage is goverend by the Let's Encrypt Subscriber Agreement.
+Prohibited certificate usage is governed by the Let's Encrypt Subscriber Agreement.
 
 ## 1.5 Policy administration
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -72,12 +72,7 @@ No stipulation.
 
 ### 1.4.2 Prohibited certificate uses
 
-Certificates may not be used:
-
-* For any application requiring fail-safe performance, such as: a) the operation of nuclear power facilities; b) air traffic control systems; c) aircraft navigation systems; d) weapons control systems; or e) any other system in which failure could lead to injury, death, or environmental damage.
-* For software or hardware architectures that provide facilities for interference with encrypted communications, including but not limited to: a) active eavesdropping (e.g., monster-in-the-middle attacks); or b) traffic management of domain names or internet protocol addresses that the organization does not own or control. Note that these restrictions shall apply regardless of whether a relying party communicating through the software or hardware architecture has knowledge of its providing facilities for interference with encrypted communications.
-
-Note that Certificates do not guarantee anything regarding reputation, honesty, or the current state of endpoint security. A Certificate only represents that the information contained in it was verified as reasonably correct when the Certificate was issued.
+Prohibited certificate usage is goverend by the Let's Encrypt Subscriber Agreement.
 
 ## 1.5 Policy administration
 


### PR DESCRIPTION
It is not the role of the CP/CPS to place restrictions on Subscriber behavior, and we already have very similar language in the Subscriber Agreement.

Fixes #205