### PR TITLE
Remove requirements around meaningful names

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -200,9 +200,7 @@ Certificate distinguished names and subject alternative names are compliant with
 
 ### 3.1.2 Need for names to be meaningful
 
-ISRG certificates include a "Subject" field which identifies the subject entity (i.e. organization or FQDN). The subject entity is identified using a distinguished name.
-
-ISRG certificates include an "Issuer" field which identifies the issuing entity. The issuing entity is identified using a distinguished name.
+No stipulation.
 
 ### 3.1.3 Anonymity or pseudonymity of subscribers
 


### PR DESCRIPTION
Section 3.1.2 is described by RFC 3647 as simply "Whether names have to be meaningful or not", with a footnote defining "meaningful" as "the name form has commonly understood semantics to determine the identity of a person and/or organization."

By this definition our certificates -- neither CA certs nor end-entity certs -- have "meaningful" names. We should accurately reflect this by simply stating "no stipulation" and not placing any additional requirements on ourselves.

Fixes https://github.com/letsencrypt/cp-cps/issues/224