### PR TITLE
Explicitly state that we do pre-issuance linting

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -322,7 +322,7 @@ No stipulation.
 
 ### 4.3.1 CA actions during certificate issuance
 
-At a high level, the following steps are taken during issuance of a Subscriber Certificate. ISRG's automated processes confirm that all names which will appear in the Common Name and/or list of SANs of the certificate have been properly validated to be controlled by the Subscriber requesting the certificate. The certificate is signed by a Subordinate CA in an HSM. After issuance is complete, the certificate is stored in a database and made available to the Subscriber.
+At a high level, the following steps are taken during issuance of a Subscriber Certificate. ISRG's automated processes confirm that all names which will appear in the Common Name and/or list of SANs of the certificate have been properly validated to be controlled by the Subscriber requesting the certificate. The to-be-signed certificate is linted, then signed by a Subordinate CA in an HSM. After issuance is complete, the certificate is stored in a database and made available to the Subscriber.
 
 ### 4.3.2 Notification to subscriber by the CA of issuance of certificate
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -1213,7 +1213,7 @@ ISRG is not required to publicly disclose any audit finding that does not impact
 
 ## 8.7 Self-Audits
 
-ISRG performs a quarterly internal audit of at least 3% of issuance since the last WebTrust audit period. The sample is randomly selected. Results are saved and provided to auditors upon request. This audit includes linting of the selected certificates.
+ISRG performs a quarterly internal audit of at least a random 3% of issuance since the last WebTrust audit period. This audit includes linting of the selected certificates. Results are saved and provided to auditors upon request.
 
 # 9. OTHER BUSINESS AND LEGAL MATTERS
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -1215,8 +1215,7 @@ ISRG is not required to publicly disclose any audit finding that does not impact
 
 ISRG performs a quarterly internal audit of at least 3% of issuance since the last WebTrust audit period.
 The sample is randomly selected. Results are saved and provided to auditors upon request.
-
-In addition, ISRG conducts pre-issuance linting for all issuance.
+This audit includes linting of the selected certificates.
 
 # 9. OTHER BUSINESS AND LEGAL MATTERS
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -1213,9 +1213,7 @@ ISRG is not required to publicly disclose any audit finding that does not impact
 
 ## 8.7 Self-Audits
 
-ISRG performs a quarterly internal audit of at least 3% of issuance since the last WebTrust audit period.
-The sample is randomly selected. Results are saved and provided to auditors upon request.
-This audit includes linting of the selected certificates.
+ISRG performs a quarterly internal audit of at least 3% of issuance since the last WebTrust audit period. The sample is randomly selected. Results are saved and provided to auditors upon request. This audit includes linting of the selected certificates.
 
 # 9. OTHER BUSINESS AND LEGAL MATTERS
 


### PR DESCRIPTION
Update Section 4.3.1 to mention our pre-issuance linting, which is now required by the BRs. Also rephrase Section 8.7 to mention our post-issuance (rather than pre-issuance) linting, in line with what that section of the BRs cares about.

Fixes https://github.com/letsencrypt/cp-cps/issues/223