### PR TITLE
Simplify statements about authentication of cert information

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -228,7 +228,7 @@ No stipulation.
 
 ### 3.2.2 Authentication of organization identity
 
-Prior to issuance of a Subscriber Certificate, ISRG uses the following methods to validate the Applicant's control of each FQDN listed in the Certificate:
+Prior to issuance of a Subscriber Certificate, ISRG uses at least one of the following methods to validate the Applicant's control of each FQDN listed in the Certificate:
 
 1. DNS Change (Baseline Requirements Section 3.2.2.4.7)
 2. Agreed-Upon Change to Website - ACME (Baseline Requirements Section 3.2.2.4.19)

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -228,9 +228,7 @@ No stipulation.
 
 ### 3.2.2 Authentication of organization identity
 
-ISRG only issues Domain Validation (DV) certificates. All FQDNs which will be listed in the Common Name and list of SANs in the certificate are fully validated prior to issuance.
-
-ISRG uses three methods for validating domain control:
+Prior to issuance of a Subscriber Certificate, ISRG uses the following methods to validate the Applicant's control of each FQDN listed in the Certificate:
 
 1. DNS Change (Baseline Requirements Section 3.2.2.4.7)
 2. Agreed-Upon Change to Website - ACME (Baseline Requirements Section 3.2.2.4.19)
@@ -242,15 +240,15 @@ All validations are performed in compliance with the current CAB Forum Baseline 
 
 ### 3.2.3 Authentication of individual identity
 
-ISRG does not issue Subscriber Certificates containing Subject Identity Information, and thus does not validate any natural person's identity.
+Not applicable.
 
 ### 3.2.4 Non-verified subscriber information
 
-Non-verified Applicant information is not included in ISRG certificates.
+Not applicable.
 
 ### 3.2.5 Validation of authority
 
-ISRG does not issue Subscriber Certificates containing Subject Identity Information, and thus does not validate any natural person's authority to request certificates on behalf of organizations.
+Not applicable.
 
 ### 3.2.6 Criteria for interoperation
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -228,7 +228,7 @@ No stipulation.
 
 ### 3.2.2 Authentication of organization identity
 
-Prior to issuance of a Subscriber Certificate, ISRG uses at least one of the following methods to validate the Applicant's control of each FQDN listed in the Certificate:
+Prior to issuance of a Subscriber Certificate, ISRG uses at least one of the following methods to validate the Applicant's control of each requested FQDN:
 
 1. DNS Change (Baseline Requirements Section 3.2.2.4.7)
 2. Agreed-Upon Change to Website - ACME (Baseline Requirements Section 3.2.2.4.19)


### PR DESCRIPTION
- Simplify 3.2.2 to more directly reflect the language used in that section of the BRs
- Replace sections 3.2.3, 3.2.4, and 3.2.5 with "No applicable", because Let's Encrypt does not need to perform authentication of individual identity or validation of authority, and does not include non-verified subscriber information in certificates

Note that this is the first use of "Not applicable." as full section contents in this document. This feels more appropriate than "No stipulation", as we are affirmatively stating that these sections do not concern our operations, rather than saying simply that we choose not to describe our operations in these sections.