### PR TITLE
Simplify Section 4.2.2 references to PSL

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -304,7 +304,7 @@ ISRG maintains a list of high-risk domains and blocks issuance of certificates f
 
 Approval requires successful completion of validation per Section 3.2.2 as well as compliance with all CA policies.
 
-Certificates containing a new gTLD under consideration by ICANN will not be issued. The CA Server is periodically updated with the latest version of the Public Suffix List and consults the ICANN domains section for every requested DNS identifier. The CA server does not validate or issue for DNS identifiers that do not have a Public Suffix in the ICANN domains section.
+The CA Server is periodically updated with the latest version of the Public Suffix List and consults the ICANN domains section for every requested DNS identifier. The CA server rejects issuance requests for DNS identifiers that do not have a Public Suffix in the ICANN domains section.
 
 ### 4.2.3 Time to process certificate applications
 


### PR DESCRIPTION
Rather than speaking about how we use the PSL to filter the TLDs of DNS names in our certificates, speak about filtering names in issuance requests.