### PR TITLE
Remove references to certificate contents from issuance process

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -332,7 +332,7 @@ See Section 2.2 of this document for Root and Subordinate CA certificate publica
 
 All Subscriber Certificates are made available to Subscribers via the ACME protocol.
 
-Prior to each Subscriber Certificate issuance, ISRG signs a corresponding Precertificate and submits it to a selection of Certificate Transparency logs. After each Subscriber Certificate issuance, ISRG submits resulting certificate to a selection of Certificate Transparency logs on a best-effort basis.
+Prior to each Subscriber Certificate issuance, ISRG signs a corresponding Precertificate and submits it to a selection of Certificate Transparency logs. After each Subscriber Certificate issuance, ISRG submits the resulting certificate to a selection of Certificate Transparency logs on a best-effort basis.
 
 ISRG does not guarantee issuance of a final certificate for every Precertificate.
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -314,7 +314,7 @@ No stipulation.
 
 ### 4.3.1 CA actions during certificate issuance
 
-At a high level, the following steps are taken during issuance of a Subscriber Certificate. ISRG's automated processes confirm that all names which will appear in the Common Name and/or list of SANs of the certificate have been properly validated to be controlled by the Subscriber requesting the certificate. The to-be-signed certificate is linted, then signed by a Subordinate CA in an HSM. After issuance is complete, the certificate is stored in a database and made available to the Subscriber.
+At a high level, the following steps are taken during issuance of a Subscriber Certificate. ISRG's automated processes confirm that all names that will be listed in the certificate have been properly validated to be controlled by the Subscriber requesting the certificate. The to-be-signed certificate is linted, then signed by a Subordinate CA in an HSM. After issuance is complete, the certificate is stored in a database and made available to the Subscriber.
 
 ### 4.3.2 Notification to subscriber by the CA of issuance of certificate
 
@@ -332,7 +332,7 @@ See Section 2.2 of this document for Root and Subordinate CA certificate publica
 
 All Subscriber Certificates are made available to Subscribers via the ACME protocol.
 
-For each Subscriber Certificate issuance, ISRG signs a Precertificate and submits it to a selection of Certificate Transparency logs. Upon successful submission, ISRG attempts to issue a certificate that matches the Precertificate (per RFC 6962 Section 3.1) and embeds at least two of the resulting Signed Certificate Timestamps (SCTs). ISRG submits the resulting final certificate to a selection of Certificate Transparency logs on a best-effort basis.
+Prior to each Subscriber Certificate issuance, ISRG signs a corresponding Precertificate and submits it to a selection of Certificate Transparency logs. After each Subscriber Certificate issuance, ISRG submits resulting certificate to a selection of Certificate Transparency logs on a best-effort basis.
 
 ISRG does not guarantee issuance of a final certificate for every Precertificate.
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -330,9 +330,7 @@ No stipulation.
 
 See Section 2.2 of this document for Root and Subordinate CA certificate publication information.
 
-All Subscriber Certificates are made available to Subscribers via the ACME protocol.
-
-Prior to each Subscriber Certificate issuance, ISRG signs a corresponding Precertificate and submits it to a selection of Certificate Transparency logs. After each Subscriber Certificate issuance, ISRG submits the resulting certificate to a selection of Certificate Transparency logs on a best-effort basis.
+All Subscriber Certificates are made available to Subscribers via the ACME protocol. They are also submitted to Certificate Transparency logs on a best-effort basis.
 
 ISRG does not guarantee issuance of a final certificate for every Precertificate.
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -314,7 +314,7 @@ No stipulation.
 
 ### 4.3.1 CA actions during certificate issuance
 
-At a high level, the following steps are taken during issuance of a Subscriber Certificate. ISRG's automated processes confirm that all names that will be listed in the certificate have been properly validated to be controlled by the Subscriber requesting the certificate. The to-be-signed certificate is linted, then signed by a Subordinate CA in an HSM. After issuance is complete, the certificate is stored in a database and made available to the Subscriber.
+At a high level, the following steps are taken during issuance of a Subscriber Certificate. ISRG's automated processes confirm that all requested names have been properly validated to be controlled by the Subscriber requesting the certificate. The to-be-signed certificate is linted, then signed by a Subordinate CA in an HSM. After issuance is complete, the certificate is stored in a database and made available to the Subscriber.
 
 ### 4.3.2 Notification to subscriber by the CA of issuance of certificate
 


### PR DESCRIPTION
Sections 4.3.1 and 4.4.2 do not need to describe certificate contents, only the actions undertaken to issue those certificates.