### PR TITLE
Reference 6.1 for key changeover

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -772,7 +772,7 @@ No stipulation.
 
 ## 5.6 Key changeover
 
-See Section 6.1.4.
+See Section 6.1.
 
 ## 5.7 Compromise and disaster recovery
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -772,7 +772,7 @@ No stipulation.
 
 ## 5.6 Key changeover
 
-See Section 2.2.
+See Section 6.1.4.
 
 ## 5.7 Compromise and disaster recovery
 


### PR DESCRIPTION
RFC 3647 says that the key changeover section "describes the procedures to provide a new public key to a CA's users following a re-key by the CA.  These procedures may be the same as the procedure for providing the current key."

Since section 6.1 describes the procedures for generating and providing the current CA keys to relying parties, it is a better reference than section 2.2.