### PR TITLE
Fix section heading spacing.

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -1336,7 +1336,7 @@ To the extent permitted by law, each Subscriber shall indemnify ISRG, its partne
 (c) the compromise or unauthorized use of a certificate or Private Key caused by the Subscriber's negligence or intentional acts; or  
 (d) Subscriber's misuse of a certificate or Private Key.
 
-### 9.9.3	Indemnification by Relying Parties
+### 9.9.3 Indemnification by Relying Parties
 
 To the extent permitted by law, each Relying Party shall indemnify ISRG, its partners, and any cross-signed entities, and their respective directors, officers, employees, agents, and contractors against any loss, damage, or expense, including reasonable attorney's fees, arising out of or related to: 
 


### PR DESCRIPTION
Minor formatting change from a tab to a space to make format consistent with other headings.