### PR TITLE
Remove "at any time"

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -456,7 +456,7 @@ Depending on the circumstances, revocation timelines can be as short as 24 hours
 
 ### 4.9.2 Who can request revocation
 
-Anyone can request revocation at any time via the certificate revocation interface of the ACME Protocol, as defined in Section 7.6 of RFC 8555.
+Anyone can request revocation via the certificate revocation interface of the ACME Protocol, as defined in Section 7.6 of RFC 8555.
 
 Requests for revocation may also be made by emailing [cert-prob-reports@letsencrypt.org](mailto:cert-prob-reports@letsencrypt.org).
 


### PR DESCRIPTION
Although we're required to maintain "a continuous 24x7 ability to accept... revocation requests", we are not required to do so via any particular interface. Our cert-prob-reports alias satisfies this requirement, so we should not tie our own hands with regards to ACME Revocation API availability.