### PR TITLE
Remove OCSP Must-Staple from Subscriber Certificate Profile

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -1030,7 +1030,6 @@ All fields are as specified in RFC 5280 and the Baseline Requirements, including
 | Authority Information Access      | Contains CA Issuers URL and optionally an OCSP URL; URLs vary based on Issuer     |
 | Subject Public Key                | See Sections 6.1.5, 6.1.6, and 7.1.3.1                                            |
 | Subject Alternative Name          | A sequence of 1 to 100 dNSNames or ipAddresses (critical if no CN)                |
-| TLS Feature                       | Contains status_request if requested by the Subscriber in the CSR                 |
 | Precertificate poison             | Per RFC 6962 (precertificates only, critical)                                     |
 | Signed Certificate Timestamp List | Per RFC 6962 (final certificates only)                                            |
 | CRL Distribution Point            | If present, contains a URI to the CRL shard whose scope includes this certificate |


### PR DESCRIPTION
We no longer issue any certificates including the OCSP Must-Staple extension. Any CSRs requesting that extension are rejected, with no resulting certificate issuance.