### PR TITLE
Bring profiles into the modern day

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -995,7 +995,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 | ----                           | ------          |
 | `tbsCertificate`               | |
 |     `version`                  | See [Section 7.1.1](#711-version-numbers) |
-|     `serialNumber`             | 128 bits of output from a CSPRNG, optionally with additional bits |
+|     `serialNumber`             | More than 100 bits of output from a CSPRNG, optionally with additional non-random bits |
 |     `signature`                | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                   | Byte-for-byte identical to the `subject` field |
 |     `validity`                 | At most 3660 days (approx. 10 years) |
@@ -1017,7 +1017,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 | ----                                 | ------          |
 | `tbsCertificate`                     | |
 |     `version`                        | See [Section 7.1.1](#711-version-numbers) |
-|     `serialNumber`                   | 128 bits of output from a CSPRNG, optionally with additional bits |
+|     `serialNumber`                   | More than 100 bits of output from a CSPRNG, optionally with additional non-random bits |
 |     `signature`                      | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                         | Byte-for-byte identical to the `subject` field of the Issuing CA |
 |     `validity`                       | At most 1098 days (approx. 3 years) |
@@ -1044,7 +1044,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 | ----                                 | ------          |
 | `tbsCertificate`                     | |
 |     `version`                        | See [Section 7.1.1](#711-version-numbers) |
-|     `serialNumber`                   | 128 bits of output from a CSPRNG, optionally with additional bits |
+|     `serialNumber`                   | More than 100 bits of output from a CSPRNG, optionally with additional non-random bits |
 |     `signature`                      | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                         | Byte-for-byte identical to the `subject` field of the Issuing CA |
 |     `validity`                       | At most 1098 days (approx. 3 years) |
@@ -1071,7 +1071,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 | ----                                     | ------          |
 | `tbsCertificate`                         | |
 |     `version`                            | See [Section 7.1.1](#711-version-numbers) |
-|     `serialNumber`                       | 136 bits of output from a CSPRNG, optionally with additional bits |
+|     `serialNumber`                       | More than 100 bits of output from a CSPRNG, optionally with additional non-random bits |
 |     `signature`                          | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                             | Byte-for-byte identical to the `subject` field of the Issuing CA |
 |     `validity`                           | At most 100 days |

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -987,70 +987,117 @@ See [Section 5.5.5](#555-requirements-for-time-stamping-of-records).
 
 ## 7.1 Certificate profile
 
-All ISRG Certificates adhere to one of the following Certificate Profiles, which are derived from the profiles with the same names found in Section 7.1.2 of the Baseline Requirements. Fields and extensions not specifically mentioned are as specified in RFC 5280 and the Baseline Requirements.
+All certificates issued by ISRG are issued in accordance with exactly one of the following profiles, which are derived from the profiles with the same names
+found in Section 7.1.2 of the Baseline Requirements.
 
 ### Root CA Certificate Profile
 
-| Field or extension             | Value                                                                   |
-| ------------------------------ | ------------------------------------------------------------------------|
-| Serial Number                  | Unique, with 64 bits of output from a CSPRNG                            |
-| Issuer Distinguished Name      | C=US, O=Internet Security Research Group or O=ISRG, and a meaningful CN |
-| Subject Distinguished Name     | Same as Issuer DN                                                       |
-| Validity Period                | Up to 25 years                                                          |
-| Basic Constraints              | cA=True, pathLength constraint absent (critical)                        |
-| Subject Public Key             | See Sections 6.1.5, 6.1.6, and 7.1.3.1                                  |
-| Key Usage                      | keyCertSign, cRLSign (critical)                                         |
+| **Field**                      | **Description** |
+| ----                           | ------          |
+| `tbsCertificate`               | |
+|     `version`                  | See [Section 7.1.1](#711-version-numbers) |
+|     `serialNumber`             | Approximately 128 bits, including at least 64 bits of output from a CSPRNG |
+|     `signature`                | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
+|     `issuer`                   | C=US, O=ISRG, and a meaningful CN |
+|     `validity`                 | At most 9132 days |
+|     `subject`                  | Byte-for-byte identical to the `issuer` field |
+|     `subjectPublicKeyInfo`     | See Sections [6.1.5](#615-key-sizes), [6.1.6](#616-public-key-parameters-generation-and-quality-checking), and [7.1.3.1](#7131-subjectpublickeyinfo) |
+|     `issuerUniqueID`           | Not present |
+|     `subjectUniqueID`          | Not present |
+|     `extensions`               | |
+|         `basicConstraints`     | Critical, with `cA` set to true |
+|         `keyUsage`             | Critical, with the `keyCertSign` (5) and `cRLSign` (6) bits set |
+|         `subjectKeyIdentifier` | Contains a truncated hash of the `subjectPublicKey`, per Section 2(1) of RFC 7093 |
+|         Any other extension    | Not present |
+| `signatureAlgorithm`           | Byte-for-byte identical to the `tbsCertificate.signature` |
+| `signatureValue`               | A signature appropriate to the `signatureAlgorithm` field |
 
 ### Cross-Certified Subordinate CA Certificate Profile
 
-| Field or extension             | Value                                                                         |
-| ------------------------------ | ----------------------------------------------------------------------------- |
-| Serial Number                  | Unique, with 64 bits of output from a CSPRNG                                  |
-| Issuer Distinguished Name      | Derived from Issuer certificate                                               |
-| Subject Distinguished Name     | Identical to the existing CA certificate                                      |
-| Validity Period                | Up to 8 years                                                                 |
-| Basic Constraints              | Identical to the existing CA certificate                                      |
-| Key Usage                      | Identical to the existing CA certificate                                      |
-| Extended Key Usage             | TLS Server Authentication and optionally TLS Client Authentication            |
-| Certificate Policies           | CAB Forum Domain Validated (2.23.140.1.2.1)                                   |
-| Authority Information Access   | Contains CA Issuers URL and optionally an OCSP URL; URLs vary based on Issuer |
-| Subject Public Key             | Identical to the existing CA certificate                                      |
-| CRL Distribution Points        | Contains a CRL URL; URL varies based on Issuer                                |
+| **Field**                            | **Description** |
+| ----                                 | ------          |
+| `tbsCertificate`                     | |
+|     `version`                        | See [Section 7.1.1](#711-version-numbers) |
+|     `serialNumber`                   | Approximately 128 bits, including at least 64 bits of output from a CSPRNG |
+|     `signature`                      | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
+|     `issuer`                         | Byte-for-byte identical to the `subject` field of the Issuing CA |
+|     `validity`                       | At most 8 years |
+|     `subject`                        | Byte-for-byte identical to the `subject` field of the existing CA Certificate |
+|     `subjectPublicKeyInfo`           | See Sections [6.1.5](#615-key-sizes), [6.1.6](#616-public-key-parameters-generation-and-quality-checking), and [7.1.3.1](#7131-subjectpublickeyinfo) |
+|     `issuerUniqueID`                 | Not present |
+|     `subjectUniqueID`                | Not present |
+|     `extensions`                     | |
+|         `authorityInformationAccess` | Contains the HTTP URI of the Issuing CA's Certificate |
+|         `authorityKeyIdentifier`     | Byte-for-byte identical to the `subjectKeyIdentifier` of the Issuing CA |
+|         `basicConstraints`           | Critical, with `cA` set to true and `pathLenConstraint` identical to the existing CA Certificate |
+|         `certificatePolicies`        | Contains the Baseline Requirements Domain Validated Reserved Policy Identifier (OID 2.23.140.1.2.1) |
+|         `crlDistributionPoints`      | Contains the HTTP URI of a CRL issued by the Issuing CA |
+|         `extKeyUsage`                | Contains `id-kp-serverAuth` (OID 1.3.6.1.5.5.7.3.1) |
+|         `keyUsage`                   | Critical, with the `keyCertSign` (5) and `cRLSign` (6) bits set |
+|         `subjectKeyIdentifier`       | Byte-for-byte identical to the `subjectKeyIdentifier` of the existing CA Certificate |
+|         Any other extension          | Not present |
+| `signatureAlgorithm`                 | Byte-for-byte identical to the `tbsCertificate.signature` |
+| `signatureValue`                     | A signature appropriate to the `signatureAlgorithm` field |
 
 ### TLS Subordinate CA Certificate Profile
 
-| Field or extension             | Value                                                                         |
-| ------------------------------ | ----------------------------------------------------------------------------- |
-| Serial Number                  | Unique, with 64 bits of output from a CSPRNG                                  |
-| Issuer Distinguished Name      | Derived from Issuer certificate                                               |
-| Subject Distinguished Name     | C=US, O=Let's Encrypt, and a meaningful CN                                    |
-| Validity Period                | Up to 8 years                                                                 |
-| Basic Constraints              | cA=True, pathLength constraint 0 (critical)                                   |
-| Key Usage                      | keyCertSign, cRLSign, digitalSignature (critical)                             |
-| Extended Key Usage             | TLS Server Authentication and optionally TLS Client Authentication            |
-| Certificate Policies           | CAB Forum Domain Validated (2.23.140.1.2.1)                                   |
-| Authority Information Access   | Contains CA Issuers URL and optionally an OCSP URL; URLs vary based on Issuer |
-| Subject Public Key             | See Sections 6.1.5, 6.1.6, and 7.1.3.1                                        |
-| CRL Distribution Points        | Contains a CRL URL; URL varies based on Issuer                                |
+| **Field**                            | **Description** |
+| ----                                 | ------          |
+| `tbsCertificate`                     | |
+|     `version`                        | See [Section 7.1.1](#711-version-numbers) |
+|     `serialNumber`                   | Approximately 128 bits, including at least 64 bits of output from a CSPRNG |
+|     `signature`                      | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
+|     `issuer`                         | Byte-for-byte identical to the `subject` field of the Issuing CA |
+|     `validity`                       | At most 8 years |
+|     `subject`                        | C=US, O=Let's Encrypt, and a meaningful CN |
+|     `subjectPublicKeyInfo`           | See Sections [6.1.5](#615-key-sizes), [6.1.6](#616-public-key-parameters-generation-and-quality-checking), and [7.1.3.1](#7131-subjectpublickeyinfo) |
+|     `issuerUniqueID`                 | Not present |
+|     `subjectUniqueID`                | Not present |
+|     `extensions`                     | |
+|         `authorityInformationAccess` | Contains the HTTP URI of the Issuing CA's Certificate |
+|         `authorityKeyIdentifier`     | Byte-for-byte identical to the `subjectKeyIdentifier` of the Issuing CA |
+|         `basicConstraints`           | Critical, with `cA` set to true and `pathLenConstraint` set to 0 |
+|         `certificatePolicies`        | Contains the Baseline Requirements Domain Validated Reserved Policy Identifier (OID 2.23.140.1.2.1) |
+|         `crlDistributionPoints`      | Contains the HTTP URI of a CRL issued by the Issuing CA |
+|         `extKeyUsage`                | Contains `id-kp-serverAuth` (OID 1.3.6.1.5.5.7.3.1) |
+|         `keyUsage`                   | Critical, with the `digitalSignature` (0), `keyCertSign` (5), and `cRLSign` (6) bits set |
+|         `subjectKeyIdentifier`       | Contains a truncated hash of the `subjectPublicKey`, per Section 2(1) of RFC 7093 |
+|         Any other extension          | Not present |
+| `signatureAlgorithm`                 | Byte-for-byte identical to the `tbsCertificate.signature` |
+| `signatureValue`                     | A signature appropriate to the `signatureAlgorithm` field |
 
-### Subscriber (End-Entity) Certificate and Precertificate Profile
+### Subscriber (Server) Certificate Profile
 
-| Field or extension                | Value                                                                             |
-| --------------------------------- | --------------------------------------------------------------------------------- |
-| Serial Number                     | Unique, with 64 bits of output from a CSPRNG                                      |
-| Issuer Distinguished Name         | Derived from Issuer certificate                                                   |
-| Subject Distinguished Name        | CN=none, or one of the values from the Subject Alternative Name extension         |
-| Validity Period                   | Up to 100 days                                                                    |
-| Basic Constraints                 | cA=False (critical)                                                               |
-| Key Usage                         | digitalSignature, and optionally keyEncipherment (critical)                       |
-| Extended Key Usage                | TLS Server Authentication and optionally TLS Client Authentication                |
-| Certificate Policies              | CAB Forum Domain Validated (2.23.140.1.2.1)                                       |
-| Authority Information Access      | Contains CA Issuers URL and optionally an OCSP URL; URLs vary based on Issuer     |
-| Subject Public Key                | See Sections 6.1.5, 6.1.6, and 7.1.3.1                                            |
-| Subject Alternative Name          | A sequence of 1 to 100 dNSNames or ipAddresses (critical if no CN)                |
-| Precertificate poison             | Per RFC 6962 (precertificates only, critical)                                     |
-| Signed Certificate Timestamp List | Per RFC 6962 (final certificates only)                                            |
-| CRL Distribution Point            | If present, contains a URI to the CRL shard whose scope includes this certificate |
+| **Field**                                | **Description** |
+| ----                                     | ------          |
+| `tbsCertificate`                         | |
+|     `version`                            | See [Section 7.1.1](#711-version-numbers) |
+|     `serialNumber`                       | Approximately 144 bits, including at least 64 bits of output from a CSPRNG |
+|     `signature`                          | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
+|     `issuer`                             | Byte-for-byte identical to the `subject` field of the Issuing CA |
+|     `validity`                           | At most 100 days |
+|     `subject`                            | CN omitted, or optionally contains one of the values from the Subject Alternative Name extension |
+|     `subjectPublicKeyInfo`               | See Sections [6.1.5](#615-key-sizes), [6.1.6](#616-public-key-parameters-generation-and-quality-checking), and [7.1.3.1](#7131-subjectpublickeyinfo) |
+|     `issuerUniqueID`                     | Not present |
+|     `subjectUniqueID`                    | Not present |
+|     `extensions`                         | |
+|         `authorityInformationAccess`     | Contains the HTTP URI of the Issuing CA's Certificate |
+|         `authorityKeyIdentifier`         | Byte-for-byte identical to the `subjectKeyIdentifier` of the Issuing CA |
+|         `basicConstraints`               | Critical, with `cA` set to false |
+|         `certificatePolicies`            | Contains the Baseline Requirements Domain Validated Reserved Policy Identifier (OID 2.23.140.1.2.1) |
+|         `crlDistributionPoints`          | Contains the HTTP URI of a CRL issued by the Issuing CA |
+|         `extKeyUsage`                    | Contains `id-kp-serverAuth` (OID 1.3.6.1.5.5.7.3.1) |
+|         `keyUsage`                       | Critical, with the `digitalSignature` (0) bit set, and optionally the `keyEnciperment` (2) bit set |
+|         `SignedCertificateTimestampList` | Contains at least two SCTs from logs run by different operators |
+|         `subjectAltName`                 | A sequence of 1 to 100 names of type `dNSName` or `ipAddress` (critical if CN omitted) |
+|         `subjectKeyIdentifier`           | Optionally contains a truncated hash of the `subjectPublicKey`, per Section 2(1) of RFC 7093 |
+|         Any other extension              | Not present |
+| `signatureAlgorithm`                     | Byte-for-byte identical to the `tbsCertificate.signature` |
+| `signatureValue`                         | A signature appropriate to the `signatureAlgorithm` field |
+
+### Precertificate Profile
+
+Identical to the Subscriber (Server) Certificate Profile, except that the `SignedCertificateTimestampList` extension is omitted, and a critical "CT poison" extension (OID 1.3.6.1.4.1.11129.2.4.3) is included. ISRG Precertificates are issued directly by the Issuing CA, not by a delegated Precertificate Signing CA.
 
 ### 7.1.1 Version number(s)
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -987,7 +987,7 @@ See [Section 5.5.5](#555-requirements-for-time-stamping-of-records).
 
 ## 7.1 Certificate profile
 
-All ISRG Certificates adhere to one of the following Certificate Profiles, which are derived from the profiles with the same names found in Section 7.1.2 of the Baseline Requirements.
+All ISRG Certificates are issued in accordance with one of the following Certificate Profiles, which are derived from the profiles with the same names found in Section 7.1.2 of the Baseline Requirements.
 
 ### Root CA Certificate Profile
 
@@ -1005,7 +1005,7 @@ All ISRG Certificates adhere to one of the following Certificate Profiles, which
 |     `subjectUniqueID`          | Not present |
 |     `extensions`               | |
 |         `basicConstraints`     | Critical, with `cA` set to true |
-|         `keyUsage`             | Critical, with the `keyCertSign` (5) and `cRLSign` (6) bits set |
+|         `keyUsage`             | Critical, with only the `keyCertSign` (5) and `cRLSign` (6) bits set |
 |         `subjectKeyIdentifier` | Contains a truncated hash of the `subjectPublicKey`, per Section 2(1) of RFC 7093 |
 |         Any other extension    | Not present |
 | `signatureAlgorithm`           | Byte-for-byte identical to the `tbsCertificate.signature` |
@@ -1027,12 +1027,12 @@ All ISRG Certificates adhere to one of the following Certificate Profiles, which
 |     `subjectUniqueID`                | Not present |
 |     `extensions`                     | |
 |         `authorityInformationAccess` | Contains the HTTP URI of the Issuing CA's Certificate |
-|         `authorityKeyIdentifier`     | Byte-for-byte identical to the `subjectKeyIdentifier` of the Issuing CA |
+|         `authorityKeyIdentifier`     | Contains a `keyIdentifier` byte-for-byte identical to the `subjectKeyIdentifier` of the Issuing CA |
 |         `basicConstraints`           | Critical, with `cA` set to true and `pathLenConstraint` identical to the existing CA Certificate |
-|         `certificatePolicies`        | Contains the Baseline Requirements Domain Validated Reserved Policy Identifier (OID 2.23.140.1.2.1) |
-|         `crlDistributionPoints`      | Contains the HTTP URI of a CRL issued by the Issuing CA |
-|         `extKeyUsage`                | Contains `id-kp-serverAuth` (OID 1.3.6.1.5.5.7.3.1) |
-|         `keyUsage`                   | Critical, with the `keyCertSign` (5) and `cRLSign` (6) bits set |
+|         `certificatePolicies`        | Contains only the Baseline Requirements Domain Validated Reserved Policy Identifier (OID 2.23.140.1.2.1) |
+|         `crlDistributionPoints`      | Contains the HTTP URI of a CRL issued by the Issuing CA whose scope includes this certificate |
+|         `extKeyUsage`                | Contains only `id-kp-serverAuth` (OID 1.3.6.1.5.5.7.3.1) |
+|         `keyUsage`                   | Critical, with only the `keyCertSign` (5) and `cRLSign` (6) bits set |
 |         `subjectKeyIdentifier`       | Byte-for-byte identical to the `subjectKeyIdentifier` of the existing CA Certificate |
 |         Any other extension          | Not present |
 | `signatureAlgorithm`                 | Byte-for-byte identical to the `tbsCertificate.signature` |
@@ -1054,12 +1054,12 @@ All ISRG Certificates adhere to one of the following Certificate Profiles, which
 |     `subjectUniqueID`                | Not present |
 |     `extensions`                     | |
 |         `authorityInformationAccess` | Contains the HTTP URI of the Issuing CA's Certificate |
-|         `authorityKeyIdentifier`     | Byte-for-byte identical to the `subjectKeyIdentifier` of the Issuing CA |
+|         `authorityKeyIdentifier`     | Contains a `keyIdentifier` byte-for-byte identical to the `subjectKeyIdentifier` of the Issuing CA |
 |         `basicConstraints`           | Critical, with `cA` set to true and `pathLenConstraint` set to 0 |
-|         `certificatePolicies`        | Contains the Baseline Requirements Domain Validated Reserved Policy Identifier (OID 2.23.140.1.2.1) |
-|         `crlDistributionPoints`      | Contains the HTTP URI of a CRL issued by the Issuing CA |
-|         `extKeyUsage`                | Contains `id-kp-serverAuth` (OID 1.3.6.1.5.5.7.3.1) |
-|         `keyUsage`                   | Critical, with the `digitalSignature` (0), `keyCertSign` (5), and `cRLSign` (6) bits set |
+|         `certificatePolicies`        | Contains only the Baseline Requirements Domain Validated Reserved Policy Identifier (OID 2.23.140.1.2.1) |
+|         `crlDistributionPoints`      | Contains the HTTP URI of a CRL issued by the Issuing CA whose scope includes this certificate |
+|         `extKeyUsage`                | Contains only `id-kp-serverAuth` (OID 1.3.6.1.5.5.7.3.1) |
+|         `keyUsage`                   | Critical, with only the `digitalSignature` (0), `keyCertSign` (5), and `cRLSign` (6) bits set |
 |         `subjectKeyIdentifier`       | Contains a truncated hash of the `subjectPublicKey`, per Section 2(1) of RFC 7093 |
 |         Any other extension          | Not present |
 | `signatureAlgorithm`                 | Byte-for-byte identical to the `tbsCertificate.signature` |
@@ -1081,12 +1081,12 @@ All ISRG Certificates adhere to one of the following Certificate Profiles, which
 |     `subjectUniqueID`                    | Not present |
 |     `extensions`                         | |
 |         `authorityInformationAccess`     | Contains the HTTP URI of the Issuing CA's Certificate |
-|         `authorityKeyIdentifier`         | Byte-for-byte identical to the `subjectKeyIdentifier` of the Issuing CA |
+|         `authorityKeyIdentifier`         | Contains a `keyIdentifier` byte-for-byte identical to the `subjectKeyIdentifier` of the Issuing CA |
 |         `basicConstraints`               | Critical, with `cA` set to false |
-|         `certificatePolicies`            | Contains the Baseline Requirements Domain Validated Reserved Policy Identifier (OID 2.23.140.1.2.1) |
-|         `crlDistributionPoints`          | Contains the HTTP URI of a CRL issued by the Issuing CA |
-|         `extKeyUsage`                    | Contains `id-kp-serverAuth` (OID 1.3.6.1.5.5.7.3.1) |
-|         `keyUsage`                       | Critical, with the `digitalSignature` (0) bit set, and optionally the `keyEnciperment` (2) bit set |
+|         `certificatePolicies`            | Contains only the Baseline Requirements Domain Validated Reserved Policy Identifier (OID 2.23.140.1.2.1) |
+|         `crlDistributionPoints`          | Contains the HTTP URI of a CRL issued by the Issuing CA whose scope includes this certificate |
+|         `extKeyUsage`                    | Contains only `id-kp-serverAuth` (OID 1.3.6.1.5.5.7.3.1) |
+|         `keyUsage`                       | Critical, with only the `digitalSignature` (0) bit (and the `keyEncipherment` (2) bit, for RSA keys) set |
 |         `SignedCertificateTimestampList` | Contains at least two SCTs from logs run by different operators |
 |         `subjectAltName`                 | A sequence of 1 to 100 names of type `dNSName` or `ipAddress` (critical if CN omitted) |
 |         `subjectKeyIdentifier`           | Optionally contains a truncated hash of the `subjectPublicKey`, per Section 2(1) of RFC 7093 |

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -1022,7 +1022,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 |     `issuer`                         | Byte-for-byte identical to the `subject` field of the Issuing CA |
 |     `validity`                       | At most 1098 days (approx. 3 years) |
 |     `subject`                        | Byte-for-byte identical to the `subject` field of the existing CA Certificate |
-|     `subjectPublicKeyInfo`           | See Sections [6.1.5](#615-key-sizes), [6.1.6](#616-public-key-parameters-generation-and-quality-checking), and [7.1.3.1](#7131-subjectpublickeyinfo) |
+|     `subjectPublicKeyInfo`           | Byte-for-byte identical to the `subjectPublicKeyInfo` field of the existing CA Certificate. See also Sections [6.1.5](#615-key-sizes), [6.1.6](#616-public-key-parameters-generation-and-quality-checking), and [7.1.3.1](#7131-subjectpublickeyinfo) |
 |     `issuerUniqueID`                 | Not present |
 |     `subjectUniqueID`                | Not present |
 |     `extensions`                     | |

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -995,7 +995,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 | ----                           | ------          |
 | `tbsCertificate`               | |
 |     `version`                  | See [Section 7.1.1](#711-version-numbers) |
-|     `serialNumber`             | Approximately 128 bits, including at least 64 bits of output from a CSPRNG |
+|     `serialNumber`             | 128 bits of output from a CSPRNG, optionally with additional bits |
 |     `signature`                | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                   | Byte-for-byte identical to the `subject` field |
 |     `validity`                 | At most 3660 days (approx. 10 years) |
@@ -1017,7 +1017,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 | ----                                 | ------          |
 | `tbsCertificate`                     | |
 |     `version`                        | See [Section 7.1.1](#711-version-numbers) |
-|     `serialNumber`                   | Approximately 128 bits, including at least 64 bits of output from a CSPRNG |
+|     `serialNumber`                   | 128 bits of output from a CSPRNG, optionally with additional bits |
 |     `signature`                      | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                         | Byte-for-byte identical to the `subject` field of the Issuing CA |
 |     `validity`                       | At most 1098 days (approx. 3 years) |
@@ -1044,7 +1044,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 | ----                                 | ------          |
 | `tbsCertificate`                     | |
 |     `version`                        | See [Section 7.1.1](#711-version-numbers) |
-|     `serialNumber`                   | Approximately 128 bits, including at least 64 bits of output from a CSPRNG |
+|     `serialNumber`                   | 128 bits of output from a CSPRNG, optionally with additional bits |
 |     `signature`                      | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                         | Byte-for-byte identical to the `subject` field of the Issuing CA |
 |     `validity`                       | At most 1098 days (approx. 3 years) |
@@ -1071,7 +1071,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 | ----                                     | ------          |
 | `tbsCertificate`                         | |
 |     `version`                            | See [Section 7.1.1](#711-version-numbers) |
-|     `serialNumber`                       | Approximately 144 bits, including at least 64 bits of output from a CSPRNG |
+|     `serialNumber`                       | 136 bits of output from a CSPRNG, optionally with additional bits |
 |     `signature`                          | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                             | Byte-for-byte identical to the `subject` field of the Issuing CA |
 |     `validity`                           | At most 100 days |

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -998,9 +998,9 @@ found in Section 7.1.2 of the Baseline Requirements.
 |     `version`                  | See [Section 7.1.1](#711-version-numbers) |
 |     `serialNumber`             | Approximately 128 bits, including at least 64 bits of output from a CSPRNG |
 |     `signature`                | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
-|     `issuer`                   | C=US, O=ISRG, and a meaningful CN |
+|     `issuer`                   | Byte-for-byte identical to the `subject` field |
 |     `validity`                 | At most 9132 days |
-|     `subject`                  | Byte-for-byte identical to the `issuer` field |
+|     `subject`                  | C=US, O=ISRG, and a unique CN |
 |     `subjectPublicKeyInfo`     | See Sections [6.1.5](#615-key-sizes), [6.1.6](#616-public-key-parameters-generation-and-quality-checking), and [7.1.3.1](#7131-subjectpublickeyinfo) |
 |     `issuerUniqueID`           | Not present |
 |     `subjectUniqueID`          | Not present |
@@ -1049,7 +1049,7 @@ found in Section 7.1.2 of the Baseline Requirements.
 |     `signature`                      | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                         | Byte-for-byte identical to the `subject` field of the Issuing CA |
 |     `validity`                       | At most 8 years |
-|     `subject`                        | C=US, O=Let's Encrypt, and a meaningful CN |
+|     `subject`                        | C=US, O=Let's Encrypt, and a unique CN |
 |     `subjectPublicKeyInfo`           | See Sections [6.1.5](#615-key-sizes), [6.1.6](#616-public-key-parameters-generation-and-quality-checking), and [7.1.3.1](#7131-subjectpublickeyinfo) |
 |     `issuerUniqueID`                 | Not present |
 |     `subjectUniqueID`                | Not present |

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -987,8 +987,7 @@ See [Section 5.5.5](#555-requirements-for-time-stamping-of-records).
 
 ## 7.1 Certificate profile
 
-All certificates issued by ISRG are issued in accordance with exactly one of the following profiles, which are derived from the profiles with the same names
-found in Section 7.1.2 of the Baseline Requirements.
+All ISRG Certificates adhere to one of the following Certificate Profiles, which are derived from the profiles with the same names found in Section 7.1.2 of the Baseline Requirements.
 
 ### Root CA Certificate Profile
 

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -998,7 +998,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 |     `serialNumber`             | Approximately 128 bits, including at least 64 bits of output from a CSPRNG |
 |     `signature`                | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                   | Byte-for-byte identical to the `subject` field |
-|     `validity`                 | At most 9132 days |
+|     `validity`                 | At most 3660 days (approx. 10 years) |
 |     `subject`                  | C=US, O=ISRG, and a unique CN |
 |     `subjectPublicKeyInfo`     | See Sections [6.1.5](#615-key-sizes), [6.1.6](#616-public-key-parameters-generation-and-quality-checking), and [7.1.3.1](#7131-subjectpublickeyinfo) |
 |     `issuerUniqueID`           | Not present |
@@ -1020,7 +1020,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 |     `serialNumber`                   | Approximately 128 bits, including at least 64 bits of output from a CSPRNG |
 |     `signature`                      | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                         | Byte-for-byte identical to the `subject` field of the Issuing CA |
-|     `validity`                       | At most 8 years |
+|     `validity`                       | At most 1098 days (approx. 3 years) |
 |     `subject`                        | Byte-for-byte identical to the `subject` field of the existing CA Certificate |
 |     `subjectPublicKeyInfo`           | See Sections [6.1.5](#615-key-sizes), [6.1.6](#616-public-key-parameters-generation-and-quality-checking), and [7.1.3.1](#7131-subjectpublickeyinfo) |
 |     `issuerUniqueID`                 | Not present |
@@ -1047,7 +1047,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 |     `serialNumber`                   | Approximately 128 bits, including at least 64 bits of output from a CSPRNG |
 |     `signature`                      | See [Section 7.1.3.2](#7132-signature-algorithmidentifier) |
 |     `issuer`                         | Byte-for-byte identical to the `subject` field of the Issuing CA |
-|     `validity`                       | At most 8 years |
+|     `validity`                       | At most 1098 days (approx. 3 years) |
 |     `subject`                        | C=US, O=Let's Encrypt, and a unique CN |
 |     `subjectPublicKeyInfo`           | See Sections [6.1.5](#615-key-sizes), [6.1.6](#616-public-key-parameters-generation-and-quality-checking), and [7.1.3.1](#7131-subjectpublickeyinfo) |
 |     `issuerUniqueID`                 | Not present |

--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -1086,7 +1086,7 @@ All ISRG Certificates are issued in accordance with one of the following Certifi
 |         `certificatePolicies`            | Contains only the Baseline Requirements Domain Validated Reserved Policy Identifier (OID 2.23.140.1.2.1) |
 |         `crlDistributionPoints`          | Contains the HTTP URI of a CRL issued by the Issuing CA whose scope includes this certificate |
 |         `extKeyUsage`                    | Contains only `id-kp-serverAuth` (OID 1.3.6.1.5.5.7.3.1) |
-|         `keyUsage`                       | Critical, with only the `digitalSignature` (0) bit (and the `keyEncipherment` (2) bit, for RSA keys) set |
+|         `keyUsage`                       | Critical, with only the `digitalSignature` (0) bit (and optionally the `keyEncipherment` (2) bit, for RSA keys) set |
 |         `SignedCertificateTimestampList` | Contains at least two SCTs from logs run by different operators |
 |         `subjectAltName`                 | A sequence of 1 to 100 names of type `dNSName` or `ipAddress` (critical if CN omitted) |
 |         `subjectKeyIdentifier`           | Optionally contains a truncated hash of the `subjectPublicKey`, per Section 2(1) of RFC 7093 |


### PR DESCRIPTION
Overhaul Section 7.1 Profiles, with two goals in mind:
- Removing deprecated pieces of our profiles, such as OCSP and the `Internet Security Research Group` Organization Name.
- Giving them the same format as the profiles in Section 7.1 of the Baseline Requirements.

Fixes https://github.com/letsencrypt/cp-cps/issues/188
Fixes https://github.com/letsencrypt/cp-cps/issues/304