### PR TITLE
Document vulnerability management timeframes

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -972,11 +972,9 @@ No stipulation.
 
 ## 6.7 Network security controls
 
-ISRG implements reasonable network security safeguards and controls to prevent unauthorized access to CA systems and infrastructure. ISRG complies with the CA/Browser Forum's Network and Certificate System Security Requirements.
+ISRG implements reasonable network security safeguards and controls to prevent unauthorized access to CA systems and infrastructure. ISRG complies with the CA/Browser Forum's Network and Certificate System Security Requirements. Identified vulnerabilities are responded to within 96 hours of review, and remediated within a timeframe based on their risk profile: critical vulnerabilities within 96 hours, high-risk within one month, medium-risk within three months, and low-risk within six months.
 
-ISRG's network is multi-tiered and utilizes the principle of defense in depth.
-
-Firewalls and other critical CA systems are configured based on a necessary-traffic-only allowlisting policy whenever possible.
+ISRG's network is multi-tiered and utilizes the principle of defense in depth. Firewalls and other critical CA systems are configured based on a necessary-traffic-only allowlisting policy whenever possible.
 
 ISRG Root CA Private Keys are stored offline in a secure manner.
 


### PR DESCRIPTION
Documenting these is required by Section 4.3 of the Network and Certificate System Security Requirements, version 2.0.5:

> The CA MUST establish one or more timeframes for reviewing, responding to, and remediating all identified vulnerabilities.

> The CA MUST document in Section 6.7 of their Certificate Policy and/or Certification Practices Statement each timeframe established for responding to and remediating vulnerabilities.

Fixes #305 