### PR TITLE
Remove irrelevant text from Section 1.6.4

### DIFF
--- a/CP-CPS.md
+++ b/CP-CPS.md
@@ -162,7 +162,7 @@ See the Baseline Requirements and NetSec Requirements for additional acronyms.
 
 ### 1.6.4 Conventions
 
-Terms not otherwise defined in this CP/CPS shall be as defined in applicable agreements, user manuals, Certificate Policies, and Certification Practice Statements of the CA.
+No stipulation.
 
 # 2. PUBLICATION AND REPOSITORY RESPONSIBILITIES
 


### PR DESCRIPTION
There are no other CPs, CPSes, etc, and we explicitly reference the definitions and acronyms from the BRs elsewhere.